### PR TITLE
Add redis-server to bootstrap.sh and fix napalm install

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -24,7 +24,7 @@ apt-get install nginx -y > /dev/null
 
 # Install Python 2
 printf "Step 5 of 19: Installing Python 3 dependencies..."
-apt-get install python3 python3-dev python3-pip libxml2-dev libxslt1-dev libffi-dev graphviz libpq-dev libssl-dev -y > /dev/null
+apt-get install python3 python3-dev python3-pip libxml2-dev libxslt1-dev libffi-dev graphviz libpq-dev libssl-dev redis-server -y > /dev/null
 
 # Upgrade pip
 printf "Step 6 of 19: Upgrading pip\n"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -90,7 +90,7 @@ python3 /opt/netbox/netbox/manage.py loaddata initial_data > /dev/null
 
 # Install NAPALM Drivers
 printf "Step 19 of 19: Installing NAPALM Drivers"
-python3 /opt/netbox/netbox/manage.py loaddata initial_data > /dev/null
+pip3 install napalm
 
 # Fix permissions to folder
 chown -R www-data /opt/netbox/netbox/media/image-attachments/


### PR DESCRIPTION
Netbox uses redis as of 6 months ago, without it installed users will get the errors below when running ```vagrant up```.

`
default: /usr/local/lib/python3.5/dist-packages/cacheops/redis.py:21: RuntimeWarning: The cacheops cache is unreachable! Error: Error 111 connecting to localhost:6379. Connection refused.
default:   warnings.warn("The cacheops cache is unreachable! Error: %s" % e, RuntimeWarning)
`

Also install napalm which addresses https://github.com/ryanmerolle/netbox-vagrant/issues/11. I ran this locally and napalm installed with no problems.